### PR TITLE
Update fabric.mod.json and classLoad rules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 	loader_version=0.11.1
 
 # Mod Properties
-	mod_version = 0.1.2-beta.2+c3d08090
+	mod_version = 0.1.2-beta.2+387afaff
 	maven_group = xyz.shurlin
 	archives_base_name = shurlin
 

--- a/src/main/java/xyz/shurlin/Shurlin.java
+++ b/src/main/java/xyz/shurlin/Shurlin.java
@@ -27,17 +27,17 @@ public class Shurlin implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        BlockEntityTypes.registerAll();
-        new Items();
+        BlockEntityTypes.load();
+        Items.load();
 //        new Features();
         RecipeSerializers.registerAll();
         Biomes.registerAll();
         BiomeGenerator.registerAll();
         ServerReceiver.registerAll();
-        new ScreenHandlerTypes();
+        ScreenHandlerTypes.load();
         ChunkGeneratorTypes.registerAll();
         Dimensions.registerAll();
-        new DimensionTypes();
+        DimensionTypes.load();
         KeyBindings.registerAll();
         Commands.registerAll();
 //        new Reflector();

--- a/src/main/java/xyz/shurlin/block/entity/BlockEntityTypes.java
+++ b/src/main/java/xyz/shurlin/block/entity/BlockEntityTypes.java
@@ -36,4 +36,6 @@ public class BlockEntityTypes {
                 new Identifier(Shurlin.MODID, registryName),
                 entry);
     }
+
+    public static void load() {}
 }

--- a/src/main/java/xyz/shurlin/item/Items.java
+++ b/src/main/java/xyz/shurlin/item/Items.java
@@ -307,4 +307,5 @@ public class Items {
         TENUOUS_TIME_SPACE_SPIRIT_ORE_BLOCK = register(Blocks.TENUOUS_TIME_SPACE_SPIRIT_ORE_BLOCK);
     }
 
+    public static void load() {}
 }

--- a/src/main/java/xyz/shurlin/screen/ScreenHandlerTypes.java
+++ b/src/main/java/xyz/shurlin/screen/ScreenHandlerTypes.java
@@ -34,4 +34,6 @@ public class ScreenHandlerTypes {
     private static <T extends ScreenHandler> ScreenHandlerType<T> register(String registryName, ScreenHandlerRegistry.SimpleClientHandlerFactory<T> entry){
             return ScreenHandlerRegistry.registerSimple(new Identifier(Shurlin.MODID, registryName), entry);
     }
+
+    public static void load() {}
 }

--- a/src/main/java/xyz/shurlin/world/dimension/DimensionTypes.java
+++ b/src/main/java/xyz/shurlin/world/dimension/DimensionTypes.java
@@ -18,4 +18,6 @@ public class DimensionTypes {
         HOLY_FARMER = register("holy_farmer_type");
 //        SHURLIN = register("shurlin");
     }
+
+    public static void load() {}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,5 +37,12 @@
   },
   "suggests": {
     "sweet_potato": ">1.0.3"
+  },
+  "custom": {
+    "Pigeonia Linkage Standard": {
+      "url": "https://featurehoues.github.io/pigeonia-linkage-standard/v1.0.0/STANDARD.txt",
+      "version": "v1.0.0",
+      "strict": false
+    }
   }
 }


### PR DESCRIPTION
View this pull request and the changes **CAREFULLY**.

- Stop using `new Items()`! Changed to `Items.load()`, which can avoid initializing an instance for `Items`.
- ~~Under @teddyxlandlee 's help,~~ Shurlin started to use linkage API follows [Pigeonia Linkage Standard v1.0.0](https://featurehouse.github.io/pigeonia-linkage-standard). @teddyxlandlee appenda it to `fabric.mod.json` according to the standard.